### PR TITLE
Don't use the default features of `num`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ repository = "https://github.com/andersk/enum_primitive-rs.git"
 homepage = "https://github.com/andersk/enum_primitive-rs"
 readme = "README.md"
 
-[dependencies]
-num = "0.1"
+[dependencies.num]
+version = "*"
+default-features = false


### PR DESCRIPTION
`num` pulls in a bunch of stuff that is not needed for `FromPrimitive`. Setting `default-features = false` doesn't preclude the user from adding `num` to their own `Cargo.toml` and enabling the default feature set there.
