### PR TITLE
Depend on num-traits instead of num

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/andersk/enum_primitive-rs.git"
 homepage = "https://github.com/andersk/enum_primitive-rs"
 readme = "README.md"
 
-[dependencies.num]
-version = "*"
+[dependencies.num-traits]
+version = "0.1.35"
 default-features = false
+
+[dev-dependencies.num]
+version = "0.1.35"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! ```
 
 
-extern crate num;
+extern crate num_traits as num;
 
 pub use std::option::Option;
 pub use num::FromPrimitive;


### PR DESCRIPTION
- Use num-traits to reduce compile times and simplify dependency graphs of projects that does not use all libraries under num
- Use semver to avoid breaking code
