### PR TITLE
Export num_traits dependency as a public module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! ```
 
 
-extern crate num_traits;
+pub extern crate num_traits;
 
 pub use std::option::Option;
 pub use num_traits::FromPrimitive;


### PR DESCRIPTION
I want to use your crate, but do not want to manualy add dependicies of your crate.
As suggested https://stackoverflow.com/questions/44876113/how-do-i-use-a-crate-from-another-crate-without-explicitly-defining-a-new-depend here I suggest export `num_traits`.