### PR TITLE
Make `enum_primitive` don't depend on std in Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,11 @@
 //! }
 //! ```
 
+#![no_std]
 
 extern crate num_traits;
 
-pub use std::option::Option;
+pub use core::option::Option;
 pub use num_traits::FromPrimitive;
 
 /// Helper macro for internal use by `enum_from_primitive!`.


### PR DESCRIPTION
Hi,
This PR removes the dependencies from `std` in Rust which makes it accessible to be used in embedded world for example.

/Niklas A