### PR TITLE
Support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ homepage = "https://github.com/andersk/enum_primitive-rs"
 readme = "README.md"
 
 [dependencies.num-traits]
-version = "0.1.32"
+version = "0.2"
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,11 @@
 //! }
 //! ```
 
+#![no_std]
 
 extern crate num_traits;
 
-pub use std::option::Option;
+pub use core::option::Option;
 pub use num_traits::FromPrimitive;
 
 /// Helper macro for internal use by `enum_from_primitive!`.


### PR DESCRIPTION
Fixes #9 

Unfortunately breaks 1.0.0 support.